### PR TITLE
pop email-templates dependencie to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "underscore": "~1.7.0",
-    "email-templates": "~1.1.0",
+    "email-templates": "~2.0.1",
     "nodemailer-smtp-transport": "~0.1.13",
     "nodemailer-stub-transport": "~0.1.4",
     "nodemailer": "~1.3.0"


### PR DESCRIPTION
Hi, 

using node >= 4.0.0, the installation failed, because of email-templates.

Updating it to latest version seems to solve the problem and the tests are still working.